### PR TITLE
Update filter paths warning test

### DIFF
--- a/tests/filter-paths.spec.ts
+++ b/tests/filter-paths.spec.ts
@@ -31,9 +31,7 @@ describe('filterOpenApiPaths', () => {
     const filtered = filterOpenApiPaths(openApiDoc as any, ['/notfound']);
     // Should return the original doc if no paths matched
     expect(filtered).toEqual(openApiDoc);
-    expect(warnSpy).toHaveBeenCalledWith(
-      '\x1b[33m[openapi-tools] Warning:\x1b[0m Path "/notfound" not found in the OpenAPI spec.'
-    );
+    expect(warnSpy).toHaveBeenCalledWith('\x1b[33m[openapi-tools] Warning:\x1b[0m Path "/notfound" not found in the OpenAPI spec.');
     warnSpy.mockRestore();
   });
 });

--- a/tests/filter-paths.spec.ts
+++ b/tests/filter-paths.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { filterOpenApiPaths } from '../src/utils/filter-paths';
 
 const openApiDoc = {
@@ -27,8 +27,13 @@ describe('filterOpenApiPaths', () => {
   });
 
   it('returns the original document if none match', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const filtered = filterOpenApiPaths(openApiDoc as any, ['/notfound']);
     // Should return the original doc if no paths matched
     expect(filtered).toEqual(openApiDoc);
+    expect(warnSpy).toHaveBeenCalledWith(
+      '\x1b[33m[openapi-tools] Warning:\x1b[0m Path "/notfound" not found in the OpenAPI spec.'
+    );
+    warnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- add `vi` import and warn spy
- check that `console.warn` is called when no paths match

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68406c7513088329b5381a6ebe2de566