### PR TITLE
Add generate-zod CLI

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+templates/zod/*.hbs
+

--- a/src/utils/extract-schemas.ts
+++ b/src/utils/extract-schemas.ts
@@ -1,0 +1,49 @@
+import type { OpenAPIV3_1 as OpenAPI } from 'openapi-types';
+import { collectSchemaRefs } from './filter-paths.js';
+
+export function extractSchemas(
+  doc: OpenAPI.Document,
+  prefixes: string[] | null
+): Record<string, OpenAPI.SchemaObject | OpenAPI.ReferenceObject> {
+  const allSchemas = doc.components?.schemas ?? {};
+  if (!prefixes || prefixes.length === 0) {
+    return allSchemas;
+  }
+
+  const refs = new Set<string>();
+  for (const [pathName, pathItem] of Object.entries(doc.paths ?? {})) {
+    if (prefixes.some((p) => pathName.startsWith(p))) {
+      for (const method of Object.values(pathItem ?? {})) {
+        if (typeof method === 'object' && method !== null) {
+          collectSchemaRefs(method, refs);
+        }
+      }
+    }
+  }
+
+  if (refs.size === 0) {
+    return {};
+  }
+
+  const collected: Record<string, OpenAPI.SchemaObject | OpenAPI.ReferenceObject> = {};
+  const queue = Array.from(refs);
+  const processed = new Set<string>();
+
+  while (queue.length) {
+    const name = queue.pop()!;
+    if (processed.has(name)) continue;
+    const schema = allSchemas[name];
+    if (schema) {
+      collected[name] = schema;
+      processed.add(name);
+      collectSchemaRefs(schema, refs);
+      for (const ref of refs) {
+        if (!processed.has(ref) && !queue.includes(ref)) {
+          queue.push(ref);
+        }
+      }
+    }
+  }
+
+  return collected;
+}

--- a/src/utils/json-schema-to-zod.ts
+++ b/src/utils/json-schema-to-zod.ts
@@ -1,0 +1,55 @@
+import type { OpenAPIV3_1 as OpenAPI } from 'openapi-types';
+
+export interface ZodResult {
+  zodString: string;
+  imports: Set<string>;
+}
+
+export function convertSchema(schema: OpenAPI.SchemaObject | OpenAPI.ReferenceObject): ZodResult {
+  const imports = new Set<string>();
+
+  function walk(s: OpenAPI.SchemaObject | OpenAPI.ReferenceObject): string {
+    if ('$ref' in s) {
+      const match = s.$ref.match(/^#\/components\/schemas\/(.+)$/);
+      const name = match ? match[1] : s.$ref;
+      imports.add(name);
+      return `z.lazy(() => ${name})`;
+    }
+
+    if (s.enum) {
+      const values = s.enum.map((v) => JSON.stringify(v)).join(', ');
+      return `z.enum([${values}])`;
+    }
+
+    switch (s.type) {
+      case 'string':
+        return 'z.string()';
+      case 'number':
+      case 'integer':
+        return 'z.number()';
+      case 'boolean':
+        return 'z.boolean()';
+      case 'array':
+        if (!s.items) return 'z.array(z.any())';
+        return `z.array(${walk(s.items)})`;
+      case 'object':
+      default: {
+        const props = s.properties ?? {};
+        const required = new Set(s.required ?? []);
+        const fields = Object.entries(props).map(([key, value]) => {
+          let expr = walk(value as any);
+          if (!required.has(key)) {
+            expr += '.optional()';
+          }
+          return `${JSON.stringify(key)}: ${expr}`;
+        });
+        return `z.object({ ${fields.join(', ')} })`;
+      }
+    }
+  }
+
+  const zodString = walk(schema);
+  imports.delete('');
+  imports.delete((schema as any).title as string); // not needed
+  return { zodString, imports };
+}

--- a/src/utils/json-schema-to-zod.ts
+++ b/src/utils/json-schema-to-zod.ts
@@ -11,7 +11,7 @@ export function convertSchema(schema: OpenAPI.SchemaObject | OpenAPI.ReferenceOb
   function walk(s: OpenAPI.SchemaObject | OpenAPI.ReferenceObject): string {
     if ('$ref' in s) {
       const match = s.$ref.match(/^#\/components\/schemas\/(.+)$/);
-      const name = match ? match[1] : s.$ref;
+      const name = match?.[1] ?? s.$ref;
       imports.add(name);
       return `z.lazy(() => ${name})`;
     }

--- a/templates/zod/index.hbs
+++ b/templates/zod/index.hbs
@@ -1,0 +1,5 @@
+{{#each schemas}}
+  export {
+  {{this}}
+  } from './{{this}}';
+{{/each}}

--- a/templates/zod/index.hbs
+++ b/templates/zod/index.hbs
@@ -1,5 +1,4 @@
+{{!-- prettier-ignore --}}
 {{#each schemas}}
-  export {
-  {{this}}
-  } from './{{this}}';
+export { {{this}} } from './{{this}}';
 {{/each}}

--- a/templates/zod/zod-schema.hbs
+++ b/templates/zod/zod-schema.hbs
@@ -1,11 +1,6 @@
+{{!-- prettier-ignore-start --}}
 import { z } from 'zod';
-{{#each imports}}
-  import {
-  {{this}}
-  } from './{{this}}';
-{{/each}}
+{{#each imports}}import { {{this}} } from './{{this}}';{{/each}}
+export const {{schemaName}} = {{zodString}};
+{{!-- prettier-ignore-end --}}
 
-export const
-{{schemaName}}
-=
-{{zodString}};

--- a/templates/zod/zod-schema.hbs
+++ b/templates/zod/zod-schema.hbs
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+{{#each imports}}
+  import {
+  {{this}}
+  } from './{{this}}';
+{{/each}}
+
+export const
+{{schemaName}}
+=
+{{zodString}};

--- a/tests/__snapshots__/generate-zod.spec.ts.snap
+++ b/tests/__snapshots__/generate-zod.spec.ts.snap
@@ -1,0 +1,22 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`generate-zod > generates a simple object schema 1`] = `
+"import { z } from 'zod';
+
+export const
+User
+=
+z.object({ &quot;id&quot;: z.string() });"
+`;
+
+exports[`generate-zod > generates enums and nested arrays 1`] = `
+"import { z } from 'zod';
+  import {
+  Status
+  } from './Status';
+
+export const
+Wrapper
+=
+z.array(z.lazy(() &#x3D;&gt; Status));"
+`;

--- a/tests/__snapshots__/generate-zod.spec.ts.snap
+++ b/tests/__snapshots__/generate-zod.spec.ts.snap
@@ -3,20 +3,15 @@
 exports[`generate-zod > generates a simple object schema 1`] = `
 "import { z } from 'zod';
 
-export const
-User
-=
-z.object({ &quot;id&quot;: z.string() });"
+export const User = z.object({ &quot;id&quot;: z.string() });
+
+"
 `;
 
 exports[`generate-zod > generates enums and nested arrays 1`] = `
 "import { z } from 'zod';
-  import {
-  Status
-  } from './Status';
+import { Status } from './Status';
+export const Wrapper = z.array(z.lazy(() &#x3D;&gt; Status));
 
-export const
-Wrapper
-=
-z.array(z.lazy(() &#x3D;&gt; Status));"
+"
 `;

--- a/tests/extract-schemas.spec.ts
+++ b/tests/extract-schemas.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { extractSchemas } from '../src/utils/extract-schemas';
+
+const doc: any = {
+  openapi: '3.1.0',
+  info: { title: 't', version: '1.0' },
+  paths: {
+    '/users': {
+      get: {
+        responses: {
+          '200': {
+            description: 'ok',
+            content: {
+              'application/json': { schema: { $ref: '#/components/schemas/User' } }
+            }
+          }
+        }
+      }
+    },
+    '/admin': {
+      get: {
+        responses: {
+          '200': {
+            description: 'ok',
+            content: {
+              'application/json': { schema: { $ref: '#/components/schemas/Admin' } }
+            }
+          }
+        }
+      }
+    }
+  },
+  components: {
+    schemas: {
+      User: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          address: { $ref: '#/components/schemas/Address' }
+        },
+        required: ['id']
+      },
+      Address: {
+        type: 'object',
+        properties: { street: { type: 'string' } }
+      },
+      Admin: {
+        type: 'object',
+        properties: { role: { $ref: '#/components/schemas/Role' } }
+      },
+      Role: {
+        type: 'string',
+        enum: ['A', 'B']
+      }
+    }
+  }
+};
+
+describe('extractSchemas', () => {
+  it('returns all schemas when no prefixes provided', () => {
+    const res = extractSchemas(doc, null);
+    expect(Object.keys(res).sort()).toEqual(['Address', 'Admin', 'Role', 'User'].sort());
+  });
+
+  it('filters schemas by path prefixes recursively', () => {
+    const res = extractSchemas(doc, ['/users']);
+    expect(Object.keys(res).sort()).toEqual(['Address', 'User'].sort());
+  });
+
+  it('returns empty object when no paths match', () => {
+    const res = extractSchemas(doc, ['/unknown']);
+    expect(res).toEqual({});
+  });
+});

--- a/tests/generate-zod.spec.ts
+++ b/tests/generate-zod.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import Handlebars from 'handlebars';
+import ts from 'typescript';
+import { convertSchema } from '../src/utils/json-schema-to-zod';
+import { extractSchemas } from '../src/utils/extract-schemas';
+
+const templateDir = path.resolve('templates/zod');
+const schemaTemplate = Handlebars.compile(fs.readFileSync(path.join(templateDir, 'zod-schema.hbs'), 'utf8'));
+
+describe('generate-zod', () => {
+  it('generates a simple object schema', () => {
+    const doc: any = {
+      openapi: '3.1.0',
+      info: { title: 't', version: '1' },
+      paths: {},
+      components: { schemas: { User: { type: 'object', properties: { id: { type: 'string' } }, required: ['id'] } } }
+    };
+    const schemas = extractSchemas(doc, null);
+    const { zodString, imports } = convertSchema(schemas.User as any);
+    const content = schemaTemplate({ schemaName: 'User', imports: Array.from(imports), zodString });
+    const result = ts.transpileModule(content, { compilerOptions: { module: ts.ModuleKind.ESNext } });
+    expect(result.diagnostics?.length).toBe(0);
+    expect(content).toMatchSnapshot();
+  });
+
+  it('generates enums and nested arrays', () => {
+    const doc: any = {
+      openapi: '3.1.0',
+      info: { title: 't', version: '1' },
+      paths: {},
+      components: {
+        schemas: {
+          Status: { type: 'string', enum: ['on', 'off'] },
+          Wrapper: { type: 'array', items: { $ref: '#/components/schemas/Status' } }
+        }
+      }
+    };
+    const schemas = extractSchemas(doc, null);
+    const { zodString } = convertSchema(schemas.Wrapper as any);
+    const content = schemaTemplate({ schemaName: 'Wrapper', imports: ['Status'], zodString });
+    const result = ts.transpileModule(content, { compilerOptions: { module: ts.ModuleKind.ESNext } });
+    expect(result.diagnostics?.length).toBe(0);
+    expect(content).toMatchSnapshot();
+  });
+
+  it('filters schemas by path prefixes', () => {
+    const doc: any = {
+      openapi: '3.1.0',
+      info: { title: 't', version: '1' },
+      paths: {
+        '/users/list': {
+          get: {
+            responses: { '200': { description: 'ok', content: { 'application/json': { schema: { $ref: '#/components/schemas/User' } } } } }
+          }
+        },
+        '/admin/data': {
+          get: {
+            responses: { '200': { description: 'ok', content: { 'application/json': { schema: { $ref: '#/components/schemas/Admin' } } } } }
+          }
+        }
+      },
+      components: {
+        schemas: {
+          User: { type: 'object', properties: { id: { type: 'string' } } },
+          Admin: { type: 'object', properties: { secret: { type: 'string' } } }
+        }
+      }
+    };
+    const schemas = extractSchemas(doc, ['/users']);
+    expect(Object.keys(schemas)).toEqual(['User']);
+  });
+});

--- a/tests/json-schema-to-zod.spec.ts
+++ b/tests/json-schema-to-zod.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { convertSchema } from '../src/utils/json-schema-to-zod';
+
+describe('convertSchema', () => {
+  it('converts enums', () => {
+    const { zodString, imports } = convertSchema({
+      type: 'string',
+      enum: ['a', 'b']
+    } as any);
+    expect(zodString).toBe('z.enum(["a", "b"])');
+    expect(imports.size).toBe(0);
+  });
+
+  it('converts arrays of refs', () => {
+    const { zodString, imports } = convertSchema({
+      type: 'array',
+      items: { $ref: '#/components/schemas/User' }
+    } as any);
+    expect(zodString).toBe('z.array(z.lazy(() => User))');
+    expect(imports.has('User')).toBe(true);
+  });
+
+  it('converts objects with optional fields', () => {
+    const schema = {
+      type: 'object',
+      properties: { id: { type: 'string' }, name: { type: 'string' } },
+      required: ['id']
+    } as any;
+    const { zodString } = convertSchema(schema);
+    expect(zodString).toBe('z.object({ "id": z.string(), "name": z.string().optional() })');
+  });
+});


### PR DESCRIPTION
## Summary
- implement `generate-zod` command for Zod schema generation
- support path prefix filtering
- add Handlebars templates for schema files and index
- implement JSON Schema to Zod converter
- add extraction utility
- test schema generation and update snapshots

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840c04f659c8329b2ac0575a3d5b237