### PR TITLE
Update TypedDict docstrings

### DIFF
--- a/src/utils/json-schema-to-typed-dict.ts
+++ b/src/utils/json-schema-to-typed-dict.ts
@@ -48,25 +48,37 @@ export function convertToTypedDict(name: string, schema: OpenAPI.SchemaObject | 
     const props = schema.properties ?? {};
     const required = new Set(schema.required ?? []);
     const fields: string[] = [];
+    const attrLines: string[] = [];
     for (const [key, value] of Object.entries(props)) {
       const typeStr = toType(value as any);
       const desc = (value as any).description;
-      if (desc) {
-        fields.push(`    # ${desc.replace(/\n/g, ' ')}`);
-      }
       if (required.has(key)) {
         typingImports.add('Required');
         fields.push(`    ${key}: Required[${typeStr}]`);
       } else {
         fields.push(`    ${key}: ${typeStr}`);
       }
+      if (desc) {
+        attrLines.push(`${key}: ${desc.replace(/\n/g, ' ')}`);
+      }
     }
     if (fields.length === 0) {
       fields.push('    pass');
     }
     const header = [`class ${name}(TypedDict, total=False):`];
+    const docLines: string[] = [];
     if (schema.description) {
-      header.push(`    """${(schema.description as string).replace(/\n/g, ' ')}"""`);
+      docLines.push((schema.description as string).replace(/\n/g, ' '));
+    }
+    if (attrLines.length > 0) {
+      if (schema.description) docLines.push('');
+      docLines.push('Attributes:');
+      for (const line of attrLines) {
+        docLines.push(`    ${line}`);
+      }
+    }
+    if (docLines.length > 0) {
+      header.push(`    """${docLines.join('\n')}"""`);
     }
     definition = `${header.join('\n')}\n${fields.join('\n')}`;
   } else {

--- a/tests/json-schema-to-typed-dict.spec.ts
+++ b/tests/json-schema-to-typed-dict.spec.ts
@@ -70,8 +70,8 @@ describe('generate-python-dict', () => {
     };
     const schemas = extractSchemas(doc, null);
     const { definition } = convertToTypedDict('User', schemas.User as any);
-    expect(definition).toContain('"""User object"""');
-    expect(definition).toContain('# identifier');
+    expect(definition).toContain('"""User object\n\nAttributes:\n    id: identifier"""');
+    expect(definition).not.toContain('# identifier');
   });
 
   it('filters schemas by path prefixes', () => {


### PR DESCRIPTION
## Summary
- generate TypedDict docstrings using Google style
- update tests for new docstring format

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684473891f90832989b9247f90ce7597