### PR TITLE
Fix typed dict ordering

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { isValidOpenapiSchema } from './utils/validation.js';
 import { extractSchemas } from './utils/extract-schemas.js';
 import { convertSchema } from './utils/json-schema-to-zod.js';
 import { convertToTypedDict } from './utils/json-schema-to-typed-dict.js';
+import { sortSchemas } from './utils/sort-schemas.js';
 import Handlebars from 'handlebars';
 
 // __dirname in ES modules
@@ -144,8 +145,9 @@ program
     const template = Handlebars.compile(templateSource);
 
     const typingImports = new Set<string>();
-    const definitions = Object.entries(schemas).map(([name, schema]) => {
-      const res = convertToTypedDict(name, schema);
+    const ordered = sortSchemas(schemas);
+    const definitions = ordered.map((name) => {
+      const res = convertToTypedDict(name, schemas[name]!);
       res.typingImports.forEach((i) => typingImports.add(i));
       return { name, definition: res.definition };
     });

--- a/src/utils/sort-schemas.ts
+++ b/src/utils/sort-schemas.ts
@@ -1,0 +1,32 @@
+import type { OpenAPIV3_1 as OpenAPI } from 'openapi-types';
+import { collectSchemaRefs } from './collect-schema-refs.js';
+
+export function sortSchemas(schemas: Record<string, OpenAPI.SchemaObject | OpenAPI.ReferenceObject>): string[] {
+  const deps: Record<string, Set<string>> = {};
+  for (const [name, schema] of Object.entries(schemas)) {
+    const refs = collectSchemaRefs(schema);
+    deps[name] = new Set(Array.from(refs).filter((r) => r in schemas && r !== name));
+  }
+
+  const ordered: string[] = [];
+  const temp = new Set<string>();
+  const perm = new Set<string>();
+
+  function visit(n: string) {
+    if (perm.has(n)) return;
+    if (temp.has(n)) return;
+    temp.add(n);
+    for (const dep of deps[n] ?? []) {
+      visit(dep);
+    }
+    perm.add(n);
+    temp.delete(n);
+    ordered.push(n);
+  }
+
+  for (const name of Object.keys(schemas)) {
+    visit(name);
+  }
+
+  return ordered;
+}

--- a/tests/sort-schemas.spec.ts
+++ b/tests/sort-schemas.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { sortSchemas } from '../src/utils/sort-schemas';
+import type { OpenAPIV3_1 as OpenAPI } from 'openapi-types';
+
+const schemas: Record<string, OpenAPI.SchemaObject | OpenAPI.ReferenceObject> = {
+  User: {
+    type: 'object',
+    properties: { address: { $ref: '#/components/schemas/Address' } },
+    required: ['address']
+  },
+  Address: { type: 'object', properties: { city: { type: 'string' } }, required: ['city'] }
+};
+
+describe('sortSchemas', () => {
+  it('orders schemas so dependencies come first', () => {
+    const order = sortSchemas(schemas);
+    expect(order.indexOf('Address')).toBeLessThan(order.indexOf('User'));
+  });
+});


### PR DESCRIPTION
## Summary
- order Python TypedDict definitions by dependency
- generate definitions in dependency order
- test sorting utility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848982f6d108329905f2e53f33dde03