### PR TITLE
Handle nested object properties

### DIFF
--- a/src/utils/json-schema-to-typed-dict.ts
+++ b/src/utils/json-schema-to-typed-dict.ts
@@ -8,6 +8,15 @@ export interface TypedDictResult {
 export function convertToTypedDict(name: string, schema: OpenAPI.SchemaObject | OpenAPI.ReferenceObject): TypedDictResult {
   const typingImports = new Set<string>(['TypedDict']);
 
+  function toPascal(str: string): string {
+    return str
+      .replace(/[^a-zA-Z0-9]+/g, ' ')
+      .split(' ')
+      .filter(Boolean)
+      .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+      .join('');
+  }
+
   function flatten(s: OpenAPI.SchemaObject | OpenAPI.ReferenceObject): { bases: string[]; schema: OpenAPI.SchemaObject | null } {
     if ('$ref' in s) {
       const match = s.$ref.match(/^#\/components\/schemas\/(.+)$/);
@@ -31,7 +40,7 @@ export function convertToTypedDict(name: string, schema: OpenAPI.SchemaObject | 
     return { bases: [], schema: s };
   }
 
-  function toType(s: OpenAPI.SchemaObject | OpenAPI.ReferenceObject): string {
+  function toType(s: OpenAPI.SchemaObject | OpenAPI.ReferenceObject, className: string): string {
     if ('$ref' in s) {
       const match = s.$ref.match(/^#\/components\/schemas\/(.+)$/);
       const refName = match?.[1] ?? s.$ref;
@@ -56,8 +65,20 @@ export function convertToTypedDict(name: string, schema: OpenAPI.SchemaObject | 
       case 'array':
         if (!s.items) return 'List[Any]';
         typingImports.add('List');
-        return `List[${toType(s.items)}]`;
+        return `List[${toType(s.items, className)}]`;
       case 'object':
+        if (s.properties && Object.keys(s.properties).length > 0) {
+          const req = new Set(s.required ?? []);
+          const fields = Object.entries(s.properties).map(([k, v]) => {
+            const t = toType(v as any, `${className}${toPascal(k)}`);
+            if (req.has(k)) {
+              typingImports.add('Required');
+              return `'${k}': Required[${t}]`;
+            }
+            return `'${k}': ${t}`;
+          });
+          return `TypedDict('${className}', { ${fields.join(', ')} }, total=False)`;
+        }
         typingImports.add('Any');
         return 'dict[str, Any]';
       default:
@@ -75,7 +96,7 @@ export function convertToTypedDict(name: string, schema: OpenAPI.SchemaObject | 
     const fields: string[] = [];
     const attrLines: string[] = [];
     for (const [key, value] of Object.entries(props)) {
-      const typeStr = toType(value as any);
+      const typeStr = toType(value as any, `${name}${toPascal(key)}`);
       const desc = (value as any).description;
       if (required.has(key)) {
         typingImports.add('Required');
@@ -108,7 +129,7 @@ export function convertToTypedDict(name: string, schema: OpenAPI.SchemaObject | 
     }
     definition = `${header.join('\n')}\n${fields.join('\n')}`;
   } else {
-    const typeStr = toType(schema);
+    const typeStr = toType(schema, name);
     definition = `${name} = ${typeStr}`;
     if ((schema as any).description) {
       definition += `  # ${((schema as any).description as string).replace(/\n/g, ' ')}`;

--- a/tests/__snapshots__/json-schema-to-typed-dict.spec.ts.snap
+++ b/tests/__snapshots__/json-schema-to-typed-dict.spec.ts.snap
@@ -30,7 +30,11 @@ class Derived(Base, TypedDict, total=False):
 
 exports[`generate-python-dict > handles inline object properties 1`] = `
 "from typing import TypedDict, Required
+class PlaceLocation(TypedDict, total=False):
+    lat: Required[float]
+    lon: float
+
 class Place(TypedDict, total=False):
     name: Required[str]
-    location: Required[TypedDict('PlaceLocation', { 'lat': Required[float], 'lon': float }, total=False)]"
+    location: Required[PlaceLocation]"
 `;

--- a/tests/__snapshots__/json-schema-to-typed-dict.spec.ts.snap
+++ b/tests/__snapshots__/json-schema-to-typed-dict.spec.ts.snap
@@ -27,3 +27,10 @@ exports[`generate-python-dict > handles allOf with refs and properties 1`] = `
 class Derived(Base, TypedDict, total=False):
     extra: Required[str]"
 `;
+
+exports[`generate-python-dict > handles inline object properties 1`] = `
+"from typing import TypedDict, Required
+class Place(TypedDict, total=False):
+    name: Required[str]
+    location: Required[TypedDict('PlaceLocation', { 'lat': Required[float], 'lon': float }, total=False)]"
+`;

--- a/tests/json-schema-to-zod.spec.ts
+++ b/tests/json-schema-to-zod.spec.ts
@@ -52,4 +52,23 @@ describe('convertSchema', () => {
     expect(zodString).toBe('z.intersection(Base, z.object({\n  extra: z.string()\n}))');
     expect(imports.has('Base')).toBe(true);
   });
+
+  it('converts inline object properties', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            flag: { type: 'boolean' }
+          },
+          required: ['id']
+        }
+      },
+      required: ['data']
+    } as OpenAPI.SchemaObject;
+    const { zodString } = convertSchema(schema);
+    expect(zodString).toBe('z.object({\n  data: z.object({\n  id: z.string(),\n  flag: z.boolean().optional()\n})\n})');
+  });
 });


### PR DESCRIPTION
## Summary
- handle nested object properties in json-schema converters
- test nested object property handling for python and zod
- name inline classes using parent property

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68489d2ac38883299f506852e9f05211