### PR TITLE
Handle oneOf during schema generation

### DIFF
--- a/src/utils/json-schema-to-typed-dict.ts
+++ b/src/utils/json-schema-to-typed-dict.ts
@@ -97,6 +97,9 @@ export function convertToTypedDict(name: string, schema: OpenAPI.SchemaObject | 
         typingImports.add('Any');
         return 'Any';
       }
+      if (s.oneOf.length === 1) {
+        return toType(s.oneOf[0] as any, className);
+      }
       typingImports.add('Union');
       const parts = s.oneOf.map((sub, idx) => toType(sub as any, `${className}Option${idx}`)).join(', ');
       return `Union[${parts}]`;
@@ -106,6 +109,9 @@ export function convertToTypedDict(name: string, schema: OpenAPI.SchemaObject | 
       if (s.anyOf.length === 0) {
         typingImports.add('Any');
         return 'Any';
+      }
+      if (s.anyOf.length === 1) {
+        return toType(s.anyOf[0] as any, className);
       }
       typingImports.add('Union');
       const parts = s.anyOf.map((sub, idx) => toType(sub as any, `${className}Option${idx}`)).join(', ');

--- a/src/utils/json-schema-to-typed-dict.ts
+++ b/src/utils/json-schema-to-typed-dict.ts
@@ -92,6 +92,26 @@ export function convertToTypedDict(name: string, schema: OpenAPI.SchemaObject | 
       return `${refName}`;
     }
 
+    if ('oneOf' in s && Array.isArray(s.oneOf)) {
+      if (s.oneOf.length === 0) {
+        typingImports.add('Any');
+        return 'Any';
+      }
+      typingImports.add('Union');
+      const parts = s.oneOf.map((sub, idx) => toType(sub as any, `${className}Option${idx}`)).join(', ');
+      return `Union[${parts}]`;
+    }
+
+    if ('anyOf' in s && Array.isArray(s.anyOf)) {
+      if (s.anyOf.length === 0) {
+        typingImports.add('Any');
+        return 'Any';
+      }
+      typingImports.add('Union');
+      const parts = s.anyOf.map((sub, idx) => toType(sub as any, `${className}Option${idx}`)).join(', ');
+      return `Union[${parts}]`;
+    }
+
     if (s.enum) {
       typingImports.add('Literal');
       const values = s.enum.map((v) => JSON.stringify(v)).join(', ');

--- a/src/utils/json-schema-to-zod.ts
+++ b/src/utils/json-schema-to-zod.ts
@@ -33,6 +33,9 @@ export function convertSchema(schema: OpenAPI.SchemaObject | OpenAPI.ReferenceOb
       if (items.length === 0) {
         return 'z.any()';
       }
+      if (items.length === 1) {
+        return walk(items[0]!);
+      }
       const parts = items.map((sub) => walk(sub)).join(', ');
       return `z.union([${parts}])`;
     }
@@ -41,6 +44,9 @@ export function convertSchema(schema: OpenAPI.SchemaObject | OpenAPI.ReferenceOb
       const items = s.anyOf as Array<OpenAPI.SchemaObject | OpenAPI.ReferenceObject>;
       if (items.length === 0) {
         return 'z.any()';
+      }
+      if (items.length === 1) {
+        return walk(items[0]!);
       }
       const parts = items.map((sub) => walk(sub)).join(', ');
       return `z.union([${parts}])`;

--- a/src/utils/json-schema-to-zod.ts
+++ b/src/utils/json-schema-to-zod.ts
@@ -28,6 +28,24 @@ export function convertSchema(schema: OpenAPI.SchemaObject | OpenAPI.ReferenceOb
       return expr;
     }
 
+    if ('oneOf' in s && Array.isArray(s.oneOf)) {
+      const items = s.oneOf as Array<OpenAPI.SchemaObject | OpenAPI.ReferenceObject>;
+      if (items.length === 0) {
+        return 'z.any()';
+      }
+      const parts = items.map((sub) => walk(sub)).join(', ');
+      return `z.union([${parts}])`;
+    }
+
+    if ('anyOf' in s && Array.isArray(s.anyOf)) {
+      const items = s.anyOf as Array<OpenAPI.SchemaObject | OpenAPI.ReferenceObject>;
+      if (items.length === 0) {
+        return 'z.any()';
+      }
+      const parts = items.map((sub) => walk(sub)).join(', ');
+      return `z.union([${parts}])`;
+    }
+
     if (s.enum) {
       const values = s.enum.map((v) => JSON.stringify(v)).join(', ');
       return `z.enum([${values}])`;

--- a/tests/__snapshots__/json-schema-to-typed-dict.spec.ts.snap
+++ b/tests/__snapshots__/json-schema-to-typed-dict.spec.ts.snap
@@ -39,6 +39,11 @@ class Place(TypedDict, total=False):
     location: Required[PlaceLocation]"
 `;
 
+exports[`generate-python-dict > handles oneOf with a single ref 1`] = `
+"from typing import TypedDict
+MessageSingle = A"
+`;
+
 exports[`generate-python-dict > handles oneOf with refs 1`] = `
 "from typing import TypedDict, Union
 Message = Union[A, B]"

--- a/tests/__snapshots__/json-schema-to-typed-dict.spec.ts.snap
+++ b/tests/__snapshots__/json-schema-to-typed-dict.spec.ts.snap
@@ -38,3 +38,8 @@ class Place(TypedDict, total=False):
     name: Required[str]
     location: Required[PlaceLocation]"
 `;
+
+exports[`generate-python-dict > handles oneOf with refs 1`] = `
+"from typing import TypedDict, Union
+Message = Union[A, B]"
+`;

--- a/tests/json-schema-to-typed-dict.spec.ts
+++ b/tests/json-schema-to-typed-dict.spec.ts
@@ -102,6 +102,30 @@ describe('generate-python-dict', () => {
     expect(content).toMatchSnapshot();
   });
 
+  it('handles oneOf with refs', () => {
+    const doc: OpenAPI.Document = {
+      openapi: '3.1.0',
+      info: { title: 't', version: '1' },
+      paths: {},
+      components: {
+        schemas: {
+          A: { type: 'object', properties: { id: { type: 'string' } } },
+          B: { type: 'object', properties: { value: { type: 'number' } } },
+          Message: { oneOf: [{ $ref: '#/components/schemas/A' }, { $ref: '#/components/schemas/B' }] }
+        }
+      }
+    };
+    const schemas = extractSchemas(doc, null);
+    const { definition, typingImports } = convertToTypedDict('Message', schemas.Message as OpenAPI.SchemaObject);
+    const typingLine = `from typing import ${Array.from(typingImports).join(', ')}`;
+    const content = [typingLine, '', definition, ''].filter(Boolean).join('\n');
+    const tmp = path.join(__dirname, 'tmp_oneof.py');
+    fs.writeFileSync(tmp, content);
+    child_process.execSync(`python3 -m py_compile ${tmp}`);
+    fs.unlinkSync(tmp);
+    expect(content).toMatchSnapshot();
+  });
+
   it('handles inline object properties', () => {
     const doc: OpenAPI.Document = {
       openapi: '3.1.0',

--- a/tests/json-schema-to-zod.spec.ts
+++ b/tests/json-schema-to-zod.spec.ts
@@ -63,6 +63,15 @@ describe('convertSchema', () => {
     expect(imports.has('B')).toBe(true);
   });
 
+  it('handles oneOf with a single ref', () => {
+    const schema = {
+      oneOf: [{ $ref: '#/components/schemas/A' }]
+    } as OpenAPI.SchemaObject;
+    const { zodString, imports } = convertSchema(schema);
+    expect(zodString).toBe('A');
+    expect(imports.has('A')).toBe(true);
+  });
+
   it('converts inline object properties', () => {
     const schema = {
       type: 'object',

--- a/tests/json-schema-to-zod.spec.ts
+++ b/tests/json-schema-to-zod.spec.ts
@@ -53,6 +53,16 @@ describe('convertSchema', () => {
     expect(imports.has('Base')).toBe(true);
   });
 
+  it('handles oneOf with refs', () => {
+    const schema = {
+      oneOf: [{ $ref: '#/components/schemas/A' }, { $ref: '#/components/schemas/B' }]
+    } as OpenAPI.SchemaObject;
+    const { zodString, imports } = convertSchema(schema);
+    expect(zodString).toBe('z.union([A, B])');
+    expect(imports.has('A')).toBe(true);
+    expect(imports.has('B')).toBe(true);
+  });
+
   it('converts inline object properties', () => {
     const schema = {
       type: 'object',


### PR DESCRIPTION
## Summary
- support `oneOf`/`anyOf` when generating Zod schemas
- support `oneOf`/`anyOf` when generating Python `TypedDicts`
- test new behaviour for union handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848afbe2c3c832985d921d07e2976ee