### PR TITLE
Handle additionalProperties for typed dicts and zod

### DIFF
--- a/src/utils/json-schema-to-typed-dict.ts
+++ b/src/utils/json-schema-to-typed-dict.ts
@@ -142,6 +142,10 @@ export function convertToTypedDict(name: string, schema: OpenAPI.SchemaObject | 
           buildClass(className, s);
           return className;
         }
+        if (s.additionalProperties && typeof s.additionalProperties === 'object') {
+          const valType = toType(s.additionalProperties as any, `${className}Additional`);
+          return `dict[str, ${valType}]`;
+        }
         typingImports.add('Any');
         return 'dict[str, Any]';
       default:

--- a/src/utils/json-schema-to-zod.ts
+++ b/src/utils/json-schema-to-zod.ts
@@ -70,6 +70,10 @@ export function convertSchema(schema: OpenAPI.SchemaObject | OpenAPI.ReferenceOb
         return `z.array(${walk(s.items)})`;
       case 'object':
       default: {
+        const hasProps = s.properties && Object.keys(s.properties).length > 0;
+        if (!hasProps && typeof s.additionalProperties === 'object') {
+          return `z.record(${walk(s.additionalProperties as any)})`;
+        }
         const props = s.properties ?? {};
         const required = new Set(s.required ?? []);
         const fields = Object.entries(props).map(([key, value]) => {

--- a/tests/__snapshots__/json-schema-to-typed-dict.spec.ts.snap
+++ b/tests/__snapshots__/json-schema-to-typed-dict.spec.ts.snap
@@ -39,6 +39,13 @@ class Place(TypedDict, total=False):
     location: Required[PlaceLocation]"
 `;
 
+exports[`generate-python-dict > handles objects with additional properties 1`] = `
+"from typing import TypedDict
+class Config(TypedDict, total=False):
+    logit_bias: dict[str, int]
+    metadata: dict[str, str]"
+`;
+
 exports[`generate-python-dict > handles oneOf with a single ref 1`] = `
 "from typing import TypedDict
 MessageSingle = A"

--- a/tests/json-schema-to-zod.spec.ts
+++ b/tests/json-schema-to-zod.spec.ts
@@ -90,4 +90,22 @@ describe('convertSchema', () => {
     const { zodString } = convertSchema(schema);
     expect(zodString).toBe('z.object({\n  data: z.object({\n  id: z.string(),\n  flag: z.boolean().optional()\n})\n})');
   });
+
+  it('converts objects with additional properties', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        logit_bias: {
+          type: 'object',
+          additionalProperties: { type: 'integer' }
+        },
+        metadata: {
+          type: 'object',
+          additionalProperties: { type: 'string' }
+        }
+      }
+    } as OpenAPI.SchemaObject;
+    const { zodString } = convertSchema(schema);
+    expect(zodString).toBe('z.object({\n  logit_bias: z.record(z.number()).optional(),\n  metadata: z.record(z.string()).optional()\n})');
+  });
 });


### PR DESCRIPTION
## Summary
- support object schemas with `additionalProperties` in python typed dict generator
- emit `z.record` when encountering `additionalProperties` in zod schema generation
- test typed records for `additionalProperties` in both python and zod converters

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848b61c2e508329a250d730d6d71e3a