### PR TITLE
Fix typed dict docstring indentation

### DIFF
--- a/src/utils/json-schema-to-typed-dict.ts
+++ b/src/utils/json-schema-to-typed-dict.ts
@@ -60,7 +60,12 @@ export function convertToTypedDict(name: string, schema: OpenAPI.SchemaObject | 
         fields.push(`    ${key}: ${typeStr}`);
       }
       if (desc) {
-        attrLines.push(`${key}: ${desc.replace(/\n/g, ' ')}`);
+        const descLines = String(desc).split('\n');
+        attrLines.push(`${key}:`);
+        for (const dl of descLines) {
+          attrLines.push(`    ${dl}`);
+        }
+        attrLines.push('');
       }
     }
     if (fields.length === 0) {
@@ -73,6 +78,7 @@ export function convertToTypedDict(name: string, schema: OpenAPI.SchemaObject | 
       docLines.push((flat.description as string).replace(/\n/g, ' '));
     }
     if (attrLines.length > 0) {
+      if (attrLines[attrLines.length - 1] === '') attrLines.pop();
       if (flat.description) docLines.push('');
       docLines.push('Attributes:');
       for (const line of attrLines) {
@@ -172,7 +178,12 @@ export function convertToTypedDict(name: string, schema: OpenAPI.SchemaObject | 
         fields.push(`    ${key}: ${typeStr}`);
       }
       if (desc) {
-        attrLines.push(`${key}: ${desc.replace(/\n/g, ' ')}`);
+        const descLines = String(desc).split('\n');
+        attrLines.push(`${key}:`);
+        for (const dl of descLines) {
+          attrLines.push(`    ${dl}`);
+        }
+        attrLines.push('');
       }
     }
     if (fields.length === 0) {
@@ -185,6 +196,7 @@ export function convertToTypedDict(name: string, schema: OpenAPI.SchemaObject | 
       docLines.push((flat.description as string).replace(/\n/g, ' '));
     }
     if (attrLines.length > 0) {
+      if (attrLines[attrLines.length - 1] === '') attrLines.pop();
       if (flat.description) docLines.push('');
       docLines.push('Attributes:');
       for (const line of attrLines) {

--- a/src/utils/json-schema-to-typed-dict.ts
+++ b/src/utils/json-schema-to-typed-dict.ts
@@ -80,7 +80,7 @@ export function convertToTypedDict(name: string, schema: OpenAPI.SchemaObject | 
       }
     }
     if (docLines.length > 0) {
-      header.push(`    """\n    ${docLines.join('\n')}\n    """`);
+      header.push(`    """\n    ${docLines.join('\n    ')}\n    """`);
     }
     extraDefs.push(`${header.join('\n')}\n${fields.join('\n')}`);
   }
@@ -192,7 +192,7 @@ export function convertToTypedDict(name: string, schema: OpenAPI.SchemaObject | 
       }
     }
     if (docLines.length > 0) {
-      header.push(`    """\n    ${docLines.join('\n')}\n    """`);
+      header.push(`    """\n    ${docLines.join('\n    ')}\n    """`);
     }
     definition = `${header.join('\n')}\n${fields.join('\n')}`;
   } else {

--- a/tests/__snapshots__/json-schema-to-typed-dict.spec.ts.snap
+++ b/tests/__snapshots__/json-schema-to-typed-dict.spec.ts.snap
@@ -4,9 +4,9 @@ exports[`generate-python-dict > adds descriptions as comments 1`] = `
 "class User(TypedDict, total=False):
     """
     User object
-
-Attributes:
-    id: identifier
+    
+    Attributes:
+        id: identifier
     """
     id: Required[str]"
 `;

--- a/tests/__snapshots__/json-schema-to-typed-dict.spec.ts.snap
+++ b/tests/__snapshots__/json-schema-to-typed-dict.spec.ts.snap
@@ -6,9 +6,27 @@ exports[`generate-python-dict > adds descriptions as comments 1`] = `
     User object
     
     Attributes:
-        id: identifier
+        id:
+            identifier
     """
     id: Required[str]"
+`;
+
+exports[`generate-python-dict > formats multiline attribute descriptions 1`] = `
+"class Multi(TypedDict, total=False):
+    """
+    Multi attr example
+    
+    Attributes:
+        id:
+            identifier
+            first line
+        
+        name:
+            the name
+    """
+    id: str
+    name: str"
 `;
 
 exports[`generate-python-dict > generates a simple object schema 1`] = `

--- a/tests/json-schema-to-typed-dict.spec.ts
+++ b/tests/json-schema-to-typed-dict.spec.ts
@@ -74,6 +74,29 @@ describe('generate-python-dict', () => {
     expect(definition).toMatchSnapshot();
   });
 
+  it('formats multiline attribute descriptions', () => {
+    const doc: OpenAPI.Document = {
+      openapi: '3.1.0',
+      info: { title: 't', version: '1' },
+      paths: {},
+      components: {
+        schemas: {
+          Multi: {
+            type: 'object',
+            description: 'Multi attr example',
+            properties: {
+              id: { type: 'string', description: 'identifier\nfirst line' },
+              name: { type: 'string', description: 'the name' }
+            }
+          }
+        }
+      }
+    };
+    const schemas = extractSchemas(doc, null);
+    const { definition } = convertToTypedDict('Multi', schemas.Multi as OpenAPI.SchemaObject);
+    expect(definition).toMatchSnapshot();
+  });
+
   it('handles allOf with refs and properties', () => {
     const doc: OpenAPI.Document = {
       openapi: '3.1.0',


### PR DESCRIPTION
## Summary
- fix indentation for `Attributes` block in typed-dict docstrings
- update snapshot for `json-schema-to-typed-dict`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848b8a5e0a083298dd77a78a8825733