### PR TITLE
Ensure consistent schema naming

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ program
       const { zodString } = convertSchema(schema);
       const desc = schema.description as string | undefined;
       return {
-        schemaName: toCamelCase(rawName),
+        schemaName: `${toCamelCase(rawName)}Schema`,
         zodString,
         description: desc ? desc.replace(/\n/g, ' ') : undefined
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { isValidOpenapiSchema } from './utils/validation.js';
 import { extractSchemas } from './utils/extract-schemas.js';
 import { convertSchema } from './utils/json-schema-to-zod.js';
 import { convertToTypedDict } from './utils/json-schema-to-typed-dict.js';
+import { toCamelCase, toPascalCase } from './utils/case.js';
 import { sortSchemas } from './utils/sort-schemas.js';
 import Handlebars from 'handlebars';
 
@@ -95,12 +96,12 @@ program
     const template = Handlebars.compile(templateSource);
 
     const ordered = sortSchemas(schemas);
-    const schemaData = ordered.map((name) => {
-      const schema = schemas[name]!;
+    const schemaData = ordered.map((rawName) => {
+      const schema = schemas[rawName]!;
       const { zodString } = convertSchema(schema);
       const desc = schema.description as string | undefined;
       return {
-        schemaName: name,
+        schemaName: toCamelCase(rawName),
         zodString,
         description: desc ? desc.replace(/\n/g, ' ') : undefined
       };
@@ -148,10 +149,10 @@ program
 
     const typingImports = new Set<string>();
     const ordered = sortSchemas(schemas);
-    const definitions = ordered.map((name) => {
-      const res = convertToTypedDict(name, schemas[name]!);
+    const definitions = ordered.map((rawName) => {
+      const res = convertToTypedDict(rawName, schemas[rawName]!);
       res.typingImports.forEach((i) => typingImports.add(i));
-      return { name, definition: res.definition };
+      return { name: toPascalCase(rawName), definition: res.definition };
     });
 
     const content = template({

--- a/src/utils/case.ts
+++ b/src/utils/case.ts
@@ -1,0 +1,13 @@
+export function toPascalCase(str: string): string {
+  return str
+    .replace(/[^a-zA-Z0-9]+/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map((p) => p.charAt(0).toUpperCase() + p.slice(1))
+    .join('');
+}
+
+export function toCamelCase(str: string): string {
+  const pascal = toPascalCase(str);
+  return pascal.charAt(0).toLowerCase() + pascal.slice(1);
+}

--- a/src/utils/json-schema-to-zod.ts
+++ b/src/utils/json-schema-to-zod.ts
@@ -1,4 +1,5 @@
 import type { OpenAPIV3_1 as OpenAPI } from 'openapi-types';
+import { toCamelCase } from './case.js';
 
 export interface ZodResult {
   zodString: string;
@@ -11,7 +12,8 @@ export function convertSchema(schema: OpenAPI.SchemaObject | OpenAPI.ReferenceOb
   function walk(s: OpenAPI.SchemaObject | OpenAPI.ReferenceObject): string {
     if ('$ref' in s) {
       const match = s.$ref.match(/^#\/components\/schemas\/(.+)$/);
-      const name = match?.[1] ?? s.$ref;
+      const raw = match?.[1] ?? s.$ref;
+      const name = toCamelCase(raw);
       imports.add(name);
       return name;
     }

--- a/src/utils/json-schema-to-zod.ts
+++ b/src/utils/json-schema-to-zod.ts
@@ -13,7 +13,7 @@ export function convertSchema(schema: OpenAPI.SchemaObject | OpenAPI.ReferenceOb
     if ('$ref' in s) {
       const match = s.$ref.match(/^#\/components\/schemas\/(.+)$/);
       const raw = match?.[1] ?? s.$ref;
-      const name = toCamelCase(raw);
+      const name = `${toCamelCase(raw)}Schema`;
       imports.add(name);
       return name;
     }

--- a/tests/__snapshots__/generate-zod.spec.ts.snap
+++ b/tests/__snapshots__/generate-zod.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`generate-zod > generates a simple object schema 1`] = `
 
 import { z } from 'zod/v4';
 
-export const user = z.object({
+export const userSchema = z.object({
   id: z.string()
 });
 "
@@ -16,6 +16,6 @@ exports[`generate-zod > generates enums and nested arrays 1`] = `
 
 import { z } from 'zod/v4';
 
-export const wrapper = z.array(status);
+export const wrapperSchema = z.array(statusSchema);
 "
 `;

--- a/tests/__snapshots__/generate-zod.spec.ts.snap
+++ b/tests/__snapshots__/generate-zod.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`generate-zod > generates a simple object schema 1`] = `
 
 import { z } from 'zod/v4';
 
-export const User = z.object({
+export const user = z.object({
   id: z.string()
 });
 "
@@ -16,6 +16,6 @@ exports[`generate-zod > generates enums and nested arrays 1`] = `
 
 import { z } from 'zod/v4';
 
-export const Wrapper = z.array(Status);
+export const wrapper = z.array(status);
 "
 `;

--- a/tests/case.spec.ts
+++ b/tests/case.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { toPascalCase, toCamelCase } from '../src/utils/case';
+
+describe('case utils', () => {
+  it('converts to PascalCase', () => {
+    expect(toPascalCase('my_schema-name')).toBe('MySchemaName');
+  });
+  it('converts to camelCase', () => {
+    expect(toCamelCase('my_schema-name')).toBe('mySchemaName');
+  });
+});

--- a/tests/generate-zod.spec.ts
+++ b/tests/generate-zod.spec.ts
@@ -21,7 +21,7 @@ describe('generate-zod', () => {
     const schemas = extractSchemas(doc, null);
     const { zodString } = convertSchema(schemas.User as OpenAPI.SchemaObject);
     const content = schemaTemplate({
-      schemas: [{ schemaName: 'User', zodString }]
+      schemas: [{ schemaName: 'user', zodString }]
     });
     const result = ts.transpileModule(content, { compilerOptions: { module: ts.ModuleKind.ESNext } });
     expect(result.diagnostics?.length).toBe(0);
@@ -43,7 +43,7 @@ describe('generate-zod', () => {
     const schemas = extractSchemas(doc, null);
     const { zodString } = convertSchema(schemas.Wrapper as OpenAPI.SchemaObject);
     const content = schemaTemplate({
-      schemas: [{ schemaName: 'Wrapper', zodString }]
+      schemas: [{ schemaName: 'wrapper', zodString }]
     });
     const result = ts.transpileModule(content, { compilerOptions: { module: ts.ModuleKind.ESNext } });
     expect(result.diagnostics?.length).toBe(0);

--- a/tests/generate-zod.spec.ts
+++ b/tests/generate-zod.spec.ts
@@ -21,7 +21,7 @@ describe('generate-zod', () => {
     const schemas = extractSchemas(doc, null);
     const { zodString } = convertSchema(schemas.User as OpenAPI.SchemaObject);
     const content = schemaTemplate({
-      schemas: [{ schemaName: 'user', zodString }]
+      schemas: [{ schemaName: 'userSchema', zodString }]
     });
     const result = ts.transpileModule(content, { compilerOptions: { module: ts.ModuleKind.ESNext } });
     expect(result.diagnostics?.length).toBe(0);
@@ -43,7 +43,7 @@ describe('generate-zod', () => {
     const schemas = extractSchemas(doc, null);
     const { zodString } = convertSchema(schemas.Wrapper as OpenAPI.SchemaObject);
     const content = schemaTemplate({
-      schemas: [{ schemaName: 'wrapper', zodString }]
+      schemas: [{ schemaName: 'wrapperSchema', zodString }]
     });
     const result = ts.transpileModule(content, { compilerOptions: { module: ts.ModuleKind.ESNext } });
     expect(result.diagnostics?.length).toBe(0);

--- a/tests/json-schema-to-zod.spec.ts
+++ b/tests/json-schema-to-zod.spec.ts
@@ -17,8 +17,8 @@ describe('convertSchema', () => {
       type: 'array',
       items: { $ref: '#/components/schemas/User' }
     } as OpenAPI.SchemaObject);
-    expect(zodString).toBe('z.array(User)');
-    expect(imports.has('User')).toBe(true);
+    expect(zodString).toBe('z.array(user)');
+    expect(imports.has('user')).toBe(true);
   });
 
   it('converts objects with optional fields', () => {
@@ -49,8 +49,8 @@ describe('convertSchema', () => {
       allOf: [{ $ref: '#/components/schemas/Base' }, { type: 'object', properties: { extra: { type: 'string' } }, required: ['extra'] }]
     } as OpenAPI.SchemaObject;
     const { zodString, imports } = convertSchema(schema);
-    expect(zodString).toBe('z.intersection(Base, z.object({\n  extra: z.string()\n}))');
-    expect(imports.has('Base')).toBe(true);
+    expect(zodString).toBe('z.intersection(base, z.object({\n  extra: z.string()\n}))');
+    expect(imports.has('base')).toBe(true);
   });
 
   it('handles oneOf with refs', () => {
@@ -58,9 +58,9 @@ describe('convertSchema', () => {
       oneOf: [{ $ref: '#/components/schemas/A' }, { $ref: '#/components/schemas/B' }]
     } as OpenAPI.SchemaObject;
     const { zodString, imports } = convertSchema(schema);
-    expect(zodString).toBe('z.union([A, B])');
-    expect(imports.has('A')).toBe(true);
-    expect(imports.has('B')).toBe(true);
+    expect(zodString).toBe('z.union([a, b])');
+    expect(imports.has('a')).toBe(true);
+    expect(imports.has('b')).toBe(true);
   });
 
   it('handles oneOf with a single ref', () => {
@@ -68,8 +68,8 @@ describe('convertSchema', () => {
       oneOf: [{ $ref: '#/components/schemas/A' }]
     } as OpenAPI.SchemaObject;
     const { zodString, imports } = convertSchema(schema);
-    expect(zodString).toBe('A');
-    expect(imports.has('A')).toBe(true);
+    expect(zodString).toBe('a');
+    expect(imports.has('a')).toBe(true);
   });
 
   it('converts inline object properties', () => {

--- a/tests/json-schema-to-zod.spec.ts
+++ b/tests/json-schema-to-zod.spec.ts
@@ -17,8 +17,8 @@ describe('convertSchema', () => {
       type: 'array',
       items: { $ref: '#/components/schemas/User' }
     } as OpenAPI.SchemaObject);
-    expect(zodString).toBe('z.array(user)');
-    expect(imports.has('user')).toBe(true);
+    expect(zodString).toBe('z.array(userSchema)');
+    expect(imports.has('userSchema')).toBe(true);
   });
 
   it('converts objects with optional fields', () => {
@@ -49,8 +49,8 @@ describe('convertSchema', () => {
       allOf: [{ $ref: '#/components/schemas/Base' }, { type: 'object', properties: { extra: { type: 'string' } }, required: ['extra'] }]
     } as OpenAPI.SchemaObject;
     const { zodString, imports } = convertSchema(schema);
-    expect(zodString).toBe('z.intersection(base, z.object({\n  extra: z.string()\n}))');
-    expect(imports.has('base')).toBe(true);
+    expect(zodString).toBe('z.intersection(baseSchema, z.object({\n  extra: z.string()\n}))');
+    expect(imports.has('baseSchema')).toBe(true);
   });
 
   it('handles oneOf with refs', () => {
@@ -58,9 +58,9 @@ describe('convertSchema', () => {
       oneOf: [{ $ref: '#/components/schemas/A' }, { $ref: '#/components/schemas/B' }]
     } as OpenAPI.SchemaObject;
     const { zodString, imports } = convertSchema(schema);
-    expect(zodString).toBe('z.union([a, b])');
-    expect(imports.has('a')).toBe(true);
-    expect(imports.has('b')).toBe(true);
+    expect(zodString).toBe('z.union([aSchema, bSchema])');
+    expect(imports.has('aSchema')).toBe(true);
+    expect(imports.has('bSchema')).toBe(true);
   });
 
   it('handles oneOf with a single ref', () => {
@@ -68,8 +68,8 @@ describe('convertSchema', () => {
       oneOf: [{ $ref: '#/components/schemas/A' }]
     } as OpenAPI.SchemaObject;
     const { zodString, imports } = convertSchema(schema);
-    expect(zodString).toBe('a');
-    expect(imports.has('a')).toBe(true);
+    expect(zodString).toBe('aSchema');
+    expect(imports.has('aSchema')).toBe(true);
   });
 
   it('converts inline object properties', () => {


### PR DESCRIPTION
## Summary
- enforce PascalCase class names and camelCase Zod schemas
- add simple case conversion helpers
- update related tests and snapshots

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849304d7d78832996d85e78abd5a60c