### PR TITLE
docs: enhance README with requirements and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
 - **Generate Zod schemas** – produce TypeScript models ready for runtime validation.
 - **Generate Python `TypedDicts`** – build strongly typed models for Python projects.
 
+## Requirements
+
+- Node.js 18 or later
+- npm 9 or later
+
 ## Installation
 
 Use `npx` for one-off runs or install globally:
@@ -22,6 +27,13 @@ The examples below use the OpenAPI Pet Store specification. More scenarios are a
 
 ```bash
 npx @ai-foundry/openapi-tools filter --input openapi.yaml --output filtered.yaml --select-paths "/pet/{petId}"
+```
+
+To generate typed models:
+
+```bash
+npx @ai-foundry/openapi-tools generate-zod --input openapi.yaml --output models.ts
+npx @ai-foundry/openapi-tools generate-python-dict --input openapi.yaml --output models.py
 ```
 
 ### Using Docker


### PR DESCRIPTION
## Summary
- document Node.js and npm prerequisites
- show how to generate TypeScript and Python models from the CLI

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b830c0ffd08329a715403ecdb4b4ab